### PR TITLE
fix: use explicit version instead of latest tag

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-toolbox:latest AS fedora-distrobox
+FROM registry.fedoraproject.org/fedora-toolbox:39 AS fedora-distrobox
 
 # Install packages required by Distrobox, this speeds up the first-run time
 RUN dnf install -y \


### PR DESCRIPTION
Somehow `registry.fedoraproject.org/fedora-toolbox:latest` now points to fedora 37. 

```
skopeo inspect docker://registry.fedoraproject.org/fedora-toolbox:latest | jq -r '.Labels'
{
  "architecture": "x86_64",
  "authoritative-source-url": "registry.fedoraproject.org",
  "build-date": "2023-10-09T13:38:04.262476",
  "com.github.containers.toolbox": "true",
  "com.redhat.build-host": "osbs-node02.iad2.fedoraproject.org",
  "com.redhat.component": "fedora-toolbox",
  "distribution-scope": "public",
  "license": "MIT",
  "maintainer": "Debarshi Ray <rishi@fedoraproject.org>",
  "name": "fedora-toolbox",
  "release": "17",
  "summary": "Base image for creating Fedora toolbox containers",
  "usage": "This image is meant to be used with the toolbox command",
  "vcs-ref": "71730c30c9e0a91bcc2d5143f447a6092b68f91c",
  "vcs-type": "git",
  "vendor": "Fedora Project",
  "version": "37"
}
```

Therefore we might be better of using `registry.fedoraproject.org/fedora-toolbox:39`
Or report it to upstream, but I have no clue where to file a report for this.